### PR TITLE
Copy headers for preventing GET 502.

### DIFF
--- a/src/coin_check.js
+++ b/src/coin_check.js
@@ -109,7 +109,7 @@ CoinCheck.prototype = {
         this.setSignature(path, paramData);
 
         if (method == 'post' || method == 'delete') {
-            headers = _.extend(headers, {
+            headers = _.extend(JSON.parse(JSON.stringify(headers)), {
                 'Content-Length': Buffer.byteLength(JSON.stringify(paramData))
             });
         }


### PR DESCRIPTION
Don't modify headers when DELETE and POST.
This is the simplest way to prevent the side effect of overwriting headers.
Or it will cause 502 when GET after DELETE/POST.